### PR TITLE
add KERNEL_VERSION as a variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ project_name = buildcharge
 USE_DEFAULT_CONFIG := 1
 KERNEL_REPO := https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 KERNEL_BRANCH := v6.12.48
+KERNEL_VERSION := 1
 
 TARGET :=
 # ramfs relies on target as aarch64, not arm64, even though they're the same.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ include scripts/make/kconfig.mk
 CMDLINE := $(project_name) console=tty0
 TMPFILE := /tmp/$(project_name)
 KERNEL_EXISTS := $(shell test -d $(KERNEL_DIR) && echo 1 || echo 0)
-EXEC := TMPFILE=$(TMPFILE) RECOVERY=$(RECOVERY) VERBOSE=$(VERBOSE) PROJECT_DIR=$(PROJECT_DIR) $(SHELL)
+EXEC := KERNEL_VERSION=$(KERNEL_VERSION) TMPFILE=$(TMPFILE) RECOVERY=$(RECOVERY) VERBOSE=$(VERBOSE) PROJECT_DIR=$(PROJECT_DIR) $(SHELL)
 
 ifeq ($(VERBOSE),1)
   CMDLINE := "$(CMDLINE) loglevel=9 console=ttyS0,115200"

--- a/scripts/build-in-buildenv.sh
+++ b/scripts/build-in-buildenv.sh
@@ -14,6 +14,6 @@ require_arg "${ENV_DIR}" "build-env dir"
 require_arg "${PROJECT_DIR}" "project dir"
 require_arg "${TARGET}" "target"
 
-COMMAND_CONTENT="rm -rf ${TMPFILE} && make --no-print-directory internal_buildenv TARGET=${TARGET} VERBOSE=${VERBOSE} BUILDENV=1 TMPFILE=${TMPFILE}"
+COMMAND_CONTENT="rm -rf ${TMPFILE} && make --no-print-directory internal_buildenv KERNEL_VERSION=${KERNEL_VERSION} TARGET=${TARGET} VERBOSE=${VERBOSE} BUILDENV=1 TMPFILE=${TMPFILE}"
 
 run_in_build_env "${ENV_DIR}" "${PROJECT_DIR}" "${COMMAND_CONTENT}"

--- a/scripts/make/buildenv.mk
+++ b/scripts/make/buildenv.mk
@@ -37,7 +37,7 @@ $(KPART): $(BZIMAGE)
 	$(Q)echo $(CMDLINE) >> $(TMPFILE)
 ifeq ($(TARGET),x86_64)
 	$(Q)apk add vboot-utils
-	$(Q)$(FUTILITY) vbutil_kernel --pack $(KPART) --signprivate $(DATA_KEY) --keyblock $(KEYBLOCK) --config $(TMPFILE) --bootloader $(TMPFILE) --vmlinuz $(BZIMAGE) --version 1 --arch $(KERNEL_TARGET)
+	$(Q)$(FUTILITY) vbutil_kernel --pack $(KPART) --signprivate $(DATA_KEY) --keyblock $(KEYBLOCK) --config $(TMPFILE) --bootloader $(TMPFILE) --vmlinuz $(BZIMAGE) --version $(KERNEL_VERSION) --arch $(KERNEL_TARGET)
 endif
 ifeq ($(TARGET),aarch64)
 ifeq ($(RECOVERY),1)
@@ -52,6 +52,7 @@ endif
 			--kernel-cmdline $(CMDLINE) \
 			--vboot-keyblock $(KEYBLOCK) \
 			--vboot-private-key $(DATA_KEY) \
+			--version $(KERNEL_VERSION) \
 			--output $(KPART)
 endif
 	$(Q)$(MKDIR) -p $(OUTDIR)

--- a/scripts/make/buildenv.mk
+++ b/scripts/make/buildenv.mk
@@ -53,7 +53,8 @@ endif
 			--vboot-keyblock $(KEYBLOCK) \
 			--vboot-private-key $(DATA_KEY) \
 			--output $(KPART)
-	$(Q)$(FUTILITY) vbutil_kernel --oldblob $(KPART) --repack $(KPART) --signprivate $(DATA_KEY) --version $(KERNEL_VERSION)
+	$(Q)cp $(KPART) /tmp/$(KPART)
+	$(Q)$(FUTILITY) vbutil_kernel --oldblob /tmp/$(KPART) --repack $(KPART) --signprivate $(DATA_KEY) --version $(KERNEL_VERSION)
 endif
 	$(Q)$(MKDIR) -p $(OUTDIR)
 	$(Q)$(COPY) $(KPART) $(OUTDIR)

--- a/scripts/make/buildenv.mk
+++ b/scripts/make/buildenv.mk
@@ -52,8 +52,8 @@ endif
 			--kernel-cmdline $(CMDLINE) \
 			--vboot-keyblock $(KEYBLOCK) \
 			--vboot-private-key $(DATA_KEY) \
-			--version $(KERNEL_VERSION) \
 			--output $(KPART)
+	$(Q)$(FUTILITY) vbutil_kernel --oldblob $(KPART) --repack $(KPART) --signprivate $(DATA_KEY) --version $(KERNEL_VERSION)
 endif
 	$(Q)$(MKDIR) -p $(OUTDIR)
 	$(Q)$(COPY) $(KPART) $(OUTDIR)


### PR DESCRIPTION
eliminates the need to use vbutil_kernel to resign the kernel with the desired kernver after building
